### PR TITLE
fix bug with empty image url, but not empty image file

### DIFF
--- a/pages/models.py
+++ b/pages/models.py
@@ -241,10 +241,13 @@ class Offers(models.Model):
         img = False
         if self.images.filter(main=True).first():
             img = self.images.filter(main=True).first()
-            if img.images_url != '':
+            if img.images_file:
                 img = img.images_file.url
+            elif img.images_url:
+                img = img.images_url
             else:
                 img = settings.NO_PHOTO_IMAGE
+
         elif self.images.first():
             img = self.images.first()
             img = img.url


### PR DESCRIPTION
сейчас получается если было загружено фото, то берется фото. Если ничего не загружалось, а фото добавлялось через сторонний УРЛ, то берется этот урл. Если оба поля пусты, то No-photo.jpg